### PR TITLE
Fix osmdata URLs in READMEs and license page

### DIFF
--- a/scripts/coastline/update.sh
+++ b/scripts/coastline/update.sh
@@ -249,7 +249,7 @@ mkshape() {
 
     local CONTENT URL
 
-    local url_prefix='http://openstreetmapdata.com/data'
+    local url_prefix='https://osmdata.openstreetmap.de/data'
 
     if [ "$layer" = 'land_polygons' ]; then
         if [[ $name = *split* ]]; then

--- a/scripts/icesheet/update-icesheet-zip.sh
+++ b/scripts/icesheet/update-icesheet-zip.sh
@@ -18,7 +18,7 @@ cd $DATADIR
 RESULTS=$DATADIR/results
 mkdir -p $RESULTS
 
-url_prefix='http://openstreetmapdata.com/data'
+url_prefix='https://osmdata.openstreetmap.de/data'
 
 for SHAPEDIR in antarctica-icesheet-* ; do
     test -d $SHAPEDIR || continue

--- a/web/info/license.html
+++ b/web/info/license.html
@@ -31,6 +31,6 @@ maps that are available under the same or a compatible license. You are
 required to attribute the OpenStreetMap contributors as required by the <a
 class="extlink" href="https://www.openstreetmap.org/copyright">OSM attribution
 requirements</a> but as in case of the ODbL licensed data we do not require you
-to attribute OpenStreetMapData.com although we'd appreciate that.</p>
+to attribute osmdata.openstreetmap.de although we'd appreciate that.</p>
 
 {% endcomment %}


### PR DESCRIPTION
`url_prefix` is used in the README files for this part:

>    You can find more information on this data set at
> 
>    http://openstreetmapdata.com/data/land-polygons

which will look like this after this change:

>    You can find more information on this data set at
> 
>    https://osmdata.openstreetmap.de/data/land-polygons

The modified part of the license page is commented out, but I guess it doesn't hurt to also update the URL there.